### PR TITLE
BUILD-2555 Improve SonarSource/vault-action-wrapper doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ jobs:
         with:
           secrets: |
             development/kv/data/sonarcloud token | sonarcloud_token;
+            development/github/token/{REPO_OWNER_NAME_DASH}-ro token | GITHUB_TOKEN;
       - uses: SonarSource/sonarcloud-github-action@<lookup latest version>
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # provided by the GitHub runner
+          GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).sonarcloud_token }}
 ```
 


### PR DESCRIPTION
* Add doc for GITHUB_TOKEN retrieval from Vault instead of github That way this example really shows how to use Vault the way RE team recommends to.