### PR TITLE
fix(BUILD-1287): fix ownership to platform-devinfra-squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-.github/CODEOWNERS @sonarsource/re-team
+.github/CODEOWNERS @sonarsource/platform-devinfra-squad


### PR DESCRIPTION
Set the team `platform-devinfra-squad` as code owner in `.github` file.

A clear unique ownership is required. See [BUILD-1271](https://jira.sonarsource.com/browse/BUILD-1271).
Contact Release Engineering Team for more information.


[BUILD-1271]: https://sonarsource.atlassian.net/browse/BUILD-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ