### PR TITLE
BUILD-5669 enforce pre commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: Pre-commit checks
+on:
+  pull_request:
+
+jobs:
+  pre-commit:
+    name: "pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/gh-action_pre-commit@15b39b4032c6f133b196430e462fc19653a697b5 # 1.0.0
+        with:
+          extra-args: >
+            --from-ref=origin/${{ github.event.pull_request.base.ref }}
+            --to-ref=${{ github.event.pull_request.head.sha }}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,7 @@
+# Default state for all rules
+default: true
+
+# MD013/line-length - Line length
+MD013:
+  line_length: 120
+  tables: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,23 +7,23 @@ repos:
       - id: check-hooks-apply
       - id: check-useless-excludes
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 3298ddab3c13dd77d6ce1fc0baf97691430d84b0  # frozen: v4.3.0
+    rev: 3298ddab3c13dd77d6ce1fc0baf97691430d84b0  # v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/adrienverge/yamllint
-    rev: 9cce2940414e9560ae4c8518ddaee2ac1863a4d2  # frozen: v1.28.0
+    rev: 9cce2940414e9560ae4c8518ddaee2ac1863a4d2  # v1.28.0
     hooks:
       - id: yamllint
         args: [-d, "{extends: default, rules: {line-length: {max: 120}}}"]
-  - repo: https://github.com/markdownlint/markdownlint
-    rev: 4089e11ea61317283a50455ff73afe895b9d8b2d  # frozen: v0.11.0
-    hooks:
-      - id: markdownlint
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 9ff55b0adf11b603e0e2b4e1d639255278f4316f  # frozen: 0.18.3
+    rev: 9ff55b0adf11b603e0e2b4e1d639255278f4316f  # 0.18.3
     hooks:
       - id: check-github-actions
       - id: check-renovate
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: c9ea83146232fb263effdfe6f222d87f5395b27a # v0.39.0
+    hooks:
+      - id: markdownlint

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ where `name` is the variable at the end of every line of the secrets
 (`jf_access_token` in the above example).
 
 ### Permissions
-The action is using OIDC to authenticate. This requires write permissions for `id-token` to fetch a JWT.
+
+The action is using OIDC to authenticate.
+This requires write permissions for `id-token` to fetch a JWT.
 
 ```yaml
 jobs:
@@ -71,12 +73,15 @@ jobs:
 ```
 
 ### Real-world examples
-* https://github.com/search?q=org%3ASonarSource+vault-action-wrapper+path%3A.github%2Fworkflows%2F&type=code
+
+* [View usage within SonarSource GitHub Organization](https://github.com/search?q=org%3ASonarSource+vault-action-wrapper+path%3A.github%2Fworkflows%2F&type=code)
 
 ## FAQ
 
 ### Error: You must provide a valid path and key. Input "some/path/to/secret | ..."
+
 This error can be raised for multiple reasons:
+
 * the requested secret is wrongly written or does not exist
 * the repository is not granted access to this secret by the RE-team
 
@@ -84,15 +89,18 @@ This error can be raised for multiple reasons:
   secret if the user is not granted to reach it.
 
 ### Timeout error
+
 Such error could be raised in case the Vault instance is unreachable.
 
 ### Error: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
+
 `id-token: write` permission is missing.
 
 ## Release
+
 Create a release from a maintained branches, then update the v* shortcut:
 
-```
+```bash
 git fetch --tags
 git update-ref -m "reset: update branch v3 to tag 3.0.0" refs/heads/v3 3.0.0
 git push origin v3


### PR DESCRIPTION
## Changes

* Use gh-action_pre-commit to enforce pre-commit validation at PR level
* Adapt the code so that all pre-commit issues are fixed
* Use a better markdown linter
* Remove freeze version that way we benefit from new versions of linters and rules