### PR TITLE
BUILD-8073 Migrate public repositories workflows to large runners

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: SonarSource/gh-action_pre-commit@fc9d73025994fd1c2b96d568c8c8a4af82a3ae21 # 1.0.6
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   vault-action:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Migrates public repository workflows from standard GitHub-hosted runners to **Large Runners**
(`ubuntu-latest` → `ubuntu-latest-large`, etc.).

See [BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073) for details.
