### PR TITLE
PREQ-3809 Add jwtTtl parameter to control GitHub OIDC token lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,36 @@ The secrets can be accessed via `fromJSON(steps.secrets.outputs.vault).name`,
 where `name` is the variable at the end of every line of the secrets
 (`jf_access_token` in the above example).
 
+### Optional Parameters
+
+#### `jwtTtl`
+
+Controls the lifetime of the GitHub OIDC JWT token used for Vault
+authentication. This directly affects how long the Vault authentication token
+(and any child secret leases) remain valid.
+
+* **Type**: `string`
+* **Default**: Not set (uses hashicorp/vault-action default of 3600 seconds =
+  1 hour)
+* **Example values**: `"10800"` (3 hours), `"7200"` (2 hours)
+
+**When to use**: Set this parameter when your workflow needs to run for longer
+than 1 hour and requires access to Vault secrets throughout its execution.
+
+```yaml
+- name: get secrets for long-running workflow
+  id: secrets
+  uses: SonarSource/vault-action-wrapper@v3
+  with:
+    jwtTtl: "10800"  # 3 hours
+    secrets: |
+      development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | artifactory_token;
+```
+
+**Important**: The `jwtTtl` must not exceed the `token_max_ttl` configured in
+Vault for the GitHub authentication role. Contact the RE team if you need to
+increase this limit.
+
 ### Permissions
 
 The action is using OIDC to authenticate.

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,12 @@ inputs:
   secrets:
     description: pattern to fetch secrets
     required: true
+  jwtTtl:
+    description: >-
+      Time in seconds for the GitHub OIDC JWT token lifetime
+      (e.g., "10800" for 3 hours). Defaults to 3600 (1 hour) if not specified.
+    required: false
+    default: ''
 outputs:
   vault:
     description: Outputs of vault
@@ -61,3 +67,4 @@ runs:
         path: jwt-ghwf
         role: ${{ steps.replace.outputs.vault-role }}
         secrets: ${{ steps.replace.outputs.pattern }}
+        jwtTtl: ${{ inputs.jwtTtl }}


### PR DESCRIPTION
## Summary

Add support for the `jwtTtl` parameter from [hashicorp/vault-action](https://github.com/hashicorp/vault-action) to control the lifetime of GitHub OIDC JWT tokens used for Vault authentication.

## Problem

GitHub Actions workflows authenticate to Vault using OIDC tokens. By default, these tokens (and the resulting Vault auth tokens) have a 1-hour TTL. When the parent Vault auth token expires after 1 hour, Vault **automatically revokes all child secret leases**, including Artifactory tokens.

This causes long-running workflows (>1h) to fail with 401 errors from Artifactory, even though the Artifactory token JWT shows a 3-hour expiration.

**Key insight**: 
- AWS STS credentials continue working after parent token expiration (AWS cannot revoke STS tokens)
- Artifactory tokens are **actively revoked** by Artifactory when Vault calls the revoke API
- This is why AWS workflows don't have this issue, but Artifactory workflows do

## Solution

This PR adds the `jwtTtl` input parameter to `vault-action-wrapper`, which is passed through to the underlying `hashicorp/vault-action`.

Workflows can now request longer-lived auth tokens to prevent premature revocation:

```yaml
- name: Get secrets for long-running workflow
  uses: SonarSource/vault-action-wrapper@feat/smarini/PREQ-3809-add-jwtTtl-support
  with:
    jwtTtl: "10800"  # 3 hours
    secrets: |
      development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | token;
```

## Changes

- Add `jwtTtl` input parameter to `action.yaml`
- Pass `jwtTtl` to `hashicorp/vault-action`
- Document parameter in `README.md` with usage examples and important notes