### PR TITLE
PREQ-3809 Update jwtTtl default to 1h and replace RE team references

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ than 1 hour and requires access to Vault secrets throughout its execution.
       development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | artifactory_token;
 ```
 
-**Important**: The `jwtTtl` must not exceed the `token_max_ttl` configured in
-Vault for the GitHub authentication role. Contact the engineering experience
-squad if you need to increase this limit.
-
 ### Permissions
 
 The action is using OIDC to authenticate.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ than 1 hour and requires access to Vault secrets throughout its execution.
 ```
 
 **Important**: The `jwtTtl` must not exceed the `token_max_ttl` configured in
-Vault for the GitHub authentication role. Contact the RE team if you need to
-increase this limit.
+Vault for the GitHub authentication role. Contact the engineering experience
+squad if you need to increase this limit.
 
 ### Permissions
 
@@ -113,7 +113,8 @@ jobs:
 This error can be raised for multiple reasons:
 
 * the requested secret is wrongly written or does not exist
-* the repository is not granted access to this secret by the RE-team
+* the repository is not granted access to this secret by the engineering
+  experience squad
 
   Due to security reason, the Vault will not tell it knows something about a
   secret if the user is not granted to reach it.

--- a/action.yaml
+++ b/action.yaml
@@ -18,7 +18,7 @@ inputs:
       Time in seconds for the GitHub OIDC JWT token lifetime
       (e.g., "10800" for 3 hours). Defaults to 3600 (1 hour) if not specified.
     required: false
-    default: ''
+    default: '3600'
 outputs:
   vault:
     description: Outputs of vault


### PR DESCRIPTION
## Summary

This PR updates the `jwtTtl` parameter to have a default value of 1 hour (3600 seconds) and replaces references to "RE team" with "engineering experience squad" throughout the documentation.

## Changes

1. **Set default `jwtTtl` value**: Changed from empty string to `'3600'` (1 hour)
   - This makes the default explicit and prevents workflows from accidentally relying on the underlying hashicorp/vault-action default
   - Workflows can still override this to request longer-lived tokens (e.g., 3 hours) when needed

2. **Update team references**: Replaced "RE team" and "RE-team" with "engineering experience squad"
   - Makes documentation consistent with current team naming
   - Updated in both the main documentation and FAQ sections

## Related

- JIRA: [PREQ-3809](https://jira.sonarsource.com/browse/PREQ-3809)
- Vault config PR: https://github.com/SonarSource/re-terraform-aws-vault/pull/8502

## Testing

This change is backward compatible:
- Existing workflows without `jwtTtl` specified will now get an explicit 1h token (same as before)
- Workflows that explicitly set `jwtTtl` will continue to work as expected

Made with [Cursor](https://cursor.com)

[PREQ-3809]: https://sonarsource.atlassian.net/browse/PREQ-3809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ