### PR TITLE
BUILD-10311 Auto-select Vault role based on GITHUB_REF

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+## Project Overview
+
+GitHub Composite Action wrapping `hashicorp/vault-action` for SonarSource. All logic lives in `action.yaml`.
+
+## Development
+
+```bash
+pre-commit run --all-files  # Linting and YAML validation
+```
+
+No build/compile steps - pure YAML action.
+
+## Testing
+
+Integration tests in `.github/workflows/test.yaml` run against staging Vault on PRs.
+
+## Role Selection
+
+Auto-selects Vault JWT role based on `GITHUB_REF`:
+
+- Protected refs (`main`, `master`, `branch-*`, `tags/*`) → `github-{org}-{repo}-protected`
+- Other refs → `github-{org}-{repo}`
+
+For pull request workflows, `GITHUB_REF` is `refs/pull/*/merge`, which does not match any protected patterns, so PRs
+always use the non-protected role.
+
+Override with explicit `role` input for backward compatibility.
+
+## Release
+
+```bash
+git fetch --tags
+git update-ref -m "reset: update branch v3 to tag X.Y.Z" refs/heads/v3 X.Y.Z
+git push origin v3
+```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ The secrets can be accessed via `fromJSON(steps.secrets.outputs.vault).name`,
 where `name` is the variable at the end of every line of the secrets
 (`jf_access_token` in the above example).
 
+### Role Selection
+
+The action automatically selects the Vault JWT role based on `GITHUB_REF`:
+
+* **Protected refs** (`refs/heads/main`, `refs/heads/master`, `refs/heads/branch-*`, `refs/tags/*`) use: `github-{org}-{repo}-protected`
+* **Other refs** (feature branches, pull request refs such as `refs/pull/*/merge`) use: `github-{org}-{repo}`
+
+Note that pull requests always use the non-protected role, even when targeting protected branches like `main` or
+`master`, because their ref (`refs/pull/*/merge`) does not match any protected ref pattern.
+
+This enables branch-based secret protection where sensitive secrets are only accessible from protected branches.
+
+To override automatic role selection, use the `role` input:
+
+```yaml
+- uses: SonarSource/vault-action-wrapper@v3
+  with:
+    role: my-custom-role
+    secrets: |
+      development/kv/data/example token | example_token;
+```
+
 ### Optional Parameters
 
 #### `jwtTtl`

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,12 @@ inputs:
       (e.g., "10800" for 3 hours). Defaults to 3600 (1 hour) if not specified.
     required: false
     default: '3600'
+  role:
+    description: |
+      Vault JWT role to use for authentication. If not provided, auto-selects based on GITHUB_REF:
+      - Protected refs (main, master, branch-*, tags/*) use 'github-{org}-{repo}-protected'
+      - Other refs use 'github-{org}-{repo}'
+    required: false
 outputs:
   vault:
     description: Outputs of vault
@@ -34,6 +40,7 @@ runs:
       # REPO_OWNER_NAME_DASH=octocat-Hello-World
       env:
         SECRET_PATTERN: ${{ inputs.secrets }}
+        INPUT_ROLE: ${{ inputs.role }}
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
@@ -56,7 +63,32 @@ runs:
                 context.repo.repo
               )
           );
-          core.setOutput('vault-role', `github-${context.repo.owner}-${context.repo.repo}`)
+
+          // Role selection logic
+          const inputRole = process.env.INPUT_ROLE;
+          const baseRole = `github-${context.repo.owner}-${context.repo.repo}`;
+
+          let selectedRole;
+          if (inputRole) {
+            // Use explicit role input (backward compatible)
+            selectedRole = inputRole;
+            core.info(`Using explicit role: ${selectedRole}`);
+          } else {
+            // Auto-select based on GITHUB_REF
+            const ref = process.env.GITHUB_REF || '';
+            const PROTECTED_REF_PATTERNS = [
+              /^refs\/heads\/main$/,
+              /^refs\/heads\/master$/,
+              /^refs\/heads\/branch-.+$/,
+              /^refs\/tags\/.+$/,
+            ];
+            const isProtectedRef = PROTECTED_REF_PATTERNS.some(pattern => pattern.test(ref));
+
+            selectedRole = isProtectedRef ? `${baseRole}-protected` : baseRole;
+            core.info(`Auto-selected role: ${selectedRole} (ref: ${ref}, protected: ${isProtectedRef})`);
+          }
+
+          core.setOutput('vault-role', selectedRole)
     - name: Vault Secrets
       id: secrets
       uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+pre-commit = "4.5.1"


### PR DESCRIPTION
## BUILD-10311 Auto-select Vault role based on GITHUB_REF

Implements automatic role selection for branch-based secret protection as part of the BUILD-10240 epic.

### Changes

- **New `role` input**: Optional parameter to explicitly specify the Vault JWT role (backward compatible)
- **Auto-selection logic**: When `role` is not provided, selects based on `GITHUB_REF`:
  - Protected refs (`refs/heads/main`, `refs/heads/master`, `refs/tags/*`) → `github-{org}-{repo}-protected`
  - Other refs → `github-{org}-{repo}`
- **Debug logging**: Logs selected role and detection reason via `core.info()`
- **Documentation**: Added Role Selection section to README

### Dependencies

- BUILD-10310 (dual JWT roles in Vault) is deployed

### Related

- POC validation: https://github.com/SonarSource/sonar-dummy/pull/548
- Epic spec: [BUILD-10240 Confluence page](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/4743397465)