### PR TITLE
PREQ-4481: Diagnose which secret path causes 403 Forbidden failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,30 @@ This error can be raised for multiple reasons:
   Due to security reason, the Vault will not tell it knows something about a
   secret if the user is not granted to reach it.
 
+### Error: Response code 403 (Forbidden)
+
+A `403 Forbidden` error means the Vault role used by the workflow does not have
+permission to read one or more of the requested secrets.
+
+The action automatically diagnoses the failure by checking each secret path
+individually and reports which specific path(s) are denied:
+
+```text
+=== Diagnosing Vault secret access failure ===
+Role: github-SonarSource-my-repo
+
+  OK      development/kv/data/repox (read)
+  DENIED  development/kv/data/slack
+  DENIED  development/artifactory/token/SonarSource-my-repo-promoter
+
+To fix, update the Vault policy for this repository:
+https://github.com/SonarSource/re-terraform-aws-vault/tree/master/orders
+```
+
+To resolve, update the Vault policy in the
+[orders repository](https://github.com/SonarSource/re-terraform-aws-vault/tree/master/orders)
+to grant the repository access to the denied secret paths.
+
 ### Timeout error
 
 Such error could be raised in case the Vault instance is unreachable.

--- a/action.yaml
+++ b/action.yaml
@@ -125,26 +125,39 @@ runs:
           core.info(`Role: ${vaultRole}`);
           core.info('');
           const denied = [];
-          for (const secretPath of secretPaths) {
-            try {
-              const resp = await fetch(`${vaultUrl}/v1/sys/capabilities-self`, {
-                method: 'POST',
-                headers: { 'X-Vault-Token': vaultToken, 'Content-Type': 'application/json' },
-                body: JSON.stringify({ path: secretPath }),
-              });
-              if (resp.ok) {
-                const data = await resp.json();
-                const caps = data.capabilities || [];
+          try {
+            const resp = await fetch(`${vaultUrl}/v1/sys/capabilities-self`, {
+              method: 'POST',
+              headers: {
+                'X-Vault-Token': vaultToken,
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({ paths: secretPaths }),
+            });
+            if (resp.ok) {
+              const data = await resp.json();
+              for (const secretPath of secretPaths) {
+                const caps = data[secretPath] ?? data.capabilities ?? [];
                 if (caps.includes('deny')) {
                   core.error(`  DENIED  ${secretPath}`);
                   denied.push(secretPath);
-                } else {
+                } else if (caps.length > 0) {
                   core.info(`  OK      ${secretPath} (${caps.join(', ')})`);
+                } else {
+                  core.warning(`  ???     ${secretPath} (no capabilities returned)`);
                 }
-              } else {
+              }
+            } else {
+              core.warning(
+                `Capability check failed with status ${resp.status}; individual results unavailable.`
+              );
+              for (const secretPath of secretPaths) {
                 core.warning(`  ???     ${secretPath} (capability check returned ${resp.status})`);
               }
-            } catch (err) {
+            }
+          } catch (err) {
+            core.warning(`Capability check failed: ${err.message}`);
+            for (const secretPath of secretPaths) {
               core.warning(`  ???     ${secretPath} (${err.message})`);
             }
           }

--- a/action.yaml
+++ b/action.yaml
@@ -37,7 +37,7 @@ runs:
       env:
         SECRET_PATTERN: ${{ inputs.secrets }}
         INPUT_ROLE: ${{ inputs.role }}
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           core.setOutput('pattern',
@@ -55,7 +55,12 @@ runs:
             core.info(`Using explicit role: ${selectedRole}`);
           } else {
             const ref = process.env.GITHUB_REF || '';
-            const PROTECTED_REF_PATTERNS = [/^refs\/heads\/main$/, /^refs\/heads\/master$/, /^refs\/heads\/branch-.+$/, /^refs\/tags\/.+$/];
+            const PROTECTED_REF_PATTERNS = [
+              /^refs\/heads\/main$/,
+              /^refs\/heads\/master$/,
+              /^refs\/heads\/branch-.+$/,
+              /^refs\/tags\/.+$/,
+            ];
             const isProtectedRef = PROTECTED_REF_PATTERNS.some(p => p.test(ref));
             selectedRole = isProtectedRef ? `${baseRole}-protected` : baseRole;
             core.info(`Auto-selected role: ${selectedRole} (ref: ${ref}, protected: ${isProtectedRef})`);
@@ -64,7 +69,7 @@ runs:
     - name: Vault Secrets
       id: secrets
       continue-on-error: true
-      uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b  # v3.4.0
       with:
         url: ${{ inputs.url }}
         exportEnv: false
@@ -76,7 +81,7 @@ runs:
     - name: Diagnose secret access failures
       id: diagnose
       if: steps.secrets.outcome == 'failure'
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       env:
         VAULT_URL: ${{ inputs.url }}
         VAULT_ROLE: ${{ steps.replace.outputs.vault-role }}
@@ -104,7 +109,9 @@ runs:
             });
             if (!loginResp.ok) {
               const body = await loginResp.text();
-              core.setFailed(`Cannot diagnose individual secrets — Vault login failed (${loginResp.status}). The role "${vaultRole}" may not exist or is misconfigured.\n${body}`);
+              const msg = `Cannot diagnose individual secrets — Vault login failed (${loginResp.status}). ` +
+                `The role "${vaultRole}" may not exist or is misconfigured.\n${body}`;
+              core.setFailed(msg);
               return;
             }
             const loginData = await loginResp.json();
@@ -147,5 +154,8 @@ runs:
             core.info('https://github.com/SonarSource/re-terraform-aws-vault/tree/master/orders');
             core.setFailed(`Vault secrets retrieval failed — ${denied.length} path(s) denied: ${denied.join(', ')}`);
           } else {
-            core.setFailed('Vault secrets retrieval failed but all paths appear individually accessible. The error may be transient or caused by a different issue.');
+            core.setFailed(
+              'Vault secrets retrieval failed but all paths appear individually accessible. ' +
+              'The error may be transient or caused by a different issue.'
+            );
           }

--- a/action.yaml
+++ b/action.yaml
@@ -91,6 +91,7 @@ runs:
           core.setOutput('vault-role', selectedRole)
     - name: Vault Secrets
       id: secrets
+      continue-on-error: true
       uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
       with:
         url: ${{ inputs.url }}
@@ -100,3 +101,103 @@ runs:
         role: ${{ steps.replace.outputs.vault-role }}
         secrets: ${{ steps.replace.outputs.pattern }}
         jwtTtl: ${{ inputs.jwtTtl }}
+    - name: Diagnose secret access failures
+      id: diagnose
+      if: steps.secrets.outcome == 'failure'
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      env:
+        VAULT_URL: ${{ inputs.url }}
+        VAULT_ROLE: ${{ steps.replace.outputs.vault-role }}
+        SECRET_PATTERN: ${{ steps.replace.outputs.pattern }}
+      with:
+        script: |
+          const vaultUrl = process.env.VAULT_URL.replace(/\/+$/, '');
+          const vaultRole = process.env.VAULT_ROLE;
+          const secretPattern = process.env.SECRET_PATTERN;
+
+          const secretPaths = [...new Set(
+            secretPattern
+              .split(/[;\n]/)
+              .map(line => line.trim())
+              .filter(line => line.length > 0)
+              .map(line => line.split(/\s+/)[0])
+              .filter(path => path.length > 0)
+          )];
+
+          if (secretPaths.length === 0) {
+            core.setFailed('Vault action failed but could not parse secret paths for diagnosis.');
+            return;
+          }
+
+          let vaultToken;
+          try {
+            const idToken = await core.getIDToken(vaultUrl);
+            const loginResp = await fetch(`${vaultUrl}/v1/auth/jwt-ghwf/login`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ role: vaultRole, jwt: idToken }),
+            });
+
+            if (!loginResp.ok) {
+              const body = await loginResp.text();
+              core.setFailed(
+                `Cannot diagnose individual secrets — Vault login failed (${loginResp.status}). ` +
+                `The role "${vaultRole}" may not exist or is misconfigured.\n${body}`
+              );
+              return;
+            }
+
+            const loginData = await loginResp.json();
+            vaultToken = loginData.auth.client_token;
+          } catch (err) {
+            core.setFailed(`Cannot diagnose individual secrets: ${err.message}`);
+            return;
+          }
+
+          core.info('');
+          core.info('=== Diagnosing Vault secret access failure ===');
+          core.info(`Role: ${vaultRole}`);
+          core.info('');
+
+          const denied = [];
+          for (const secretPath of secretPaths) {
+            try {
+              const resp = await fetch(`${vaultUrl}/v1/sys/capabilities-self`, {
+                method: 'POST',
+                headers: {
+                  'X-Vault-Token': vaultToken,
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ path: secretPath }),
+              });
+
+              if (resp.ok) {
+                const data = await resp.json();
+                const caps = data.capabilities || [];
+                if (caps.includes('deny')) {
+                  core.error(`  DENIED  ${secretPath}`);
+                  denied.push(secretPath);
+                } else {
+                  core.info(`  OK      ${secretPath} (${caps.join(', ')})`);
+                }
+              } else {
+                core.warning(`  ???     ${secretPath} (capability check returned ${resp.status})`);
+              }
+            } catch (err) {
+              core.warning(`  ???     ${secretPath} (${err.message})`);
+            }
+          }
+
+          core.info('');
+          if (denied.length > 0) {
+            core.info('To fix, update the Vault policy for this repository:');
+            core.info('https://github.com/SonarSource/re-terraform-aws-vault/tree/master/orders');
+            core.setFailed(
+              `Vault secrets retrieval failed — ${denied.length} path(s) denied: ${denied.join(', ')}`
+            );
+          } else {
+            core.setFailed(
+              'Vault secrets retrieval failed but all paths appear individually accessible. ' +
+              'The error may be transient or caused by a different issue.'
+            );
+          }

--- a/action.yaml
+++ b/action.yaml
@@ -34,10 +34,6 @@ runs:
   steps:
     - name: replace placeholder
       id: replace
-      # GITHUB_REPOSITORY=octocat/Hello-World
-      # GITHUB_REPOSITORY_OWNER=octocat
-      # REPO_NAME=Hello-World
-      # REPO_OWNER_NAME_DASH=octocat-Hello-World
       env:
         SECRET_PATTERN: ${{ inputs.secrets }}
         INPUT_ROLE: ${{ inputs.role }}
@@ -46,48 +42,24 @@ runs:
         script: |
           core.setOutput('pattern',
             process.env.SECRET_PATTERN
-              .replaceAll(
-                '{GITHUB_REPOSITORY_OWNER}',
-                context.repo.owner
-              )
-              .replaceAll(
-                '{GITHUB_REPOSITORY}',
-                `${context.repo.owner}/${context.repo.repo}`
-              )
-              .replaceAll(
-                '{REPO_OWNER_NAME_DASH}',
-                `${context.repo.owner}-${context.repo.repo}`
-              )
-              .replaceAll(
-                '{REPO_NAME}',
-                context.repo.repo
-              )
+              .replaceAll('{GITHUB_REPOSITORY_OWNER}', context.repo.owner)
+              .replaceAll('{GITHUB_REPOSITORY}', `${context.repo.owner}/${context.repo.repo}`)
+              .replaceAll('{REPO_OWNER_NAME_DASH}', `${context.repo.owner}-${context.repo.repo}`)
+              .replaceAll('{REPO_NAME}', context.repo.repo)
           );
-
-          // Role selection logic
           const inputRole = process.env.INPUT_ROLE;
           const baseRole = `github-${context.repo.owner}-${context.repo.repo}`;
-
           let selectedRole;
           if (inputRole) {
-            // Use explicit role input (backward compatible)
             selectedRole = inputRole;
             core.info(`Using explicit role: ${selectedRole}`);
           } else {
-            // Auto-select based on GITHUB_REF
             const ref = process.env.GITHUB_REF || '';
-            const PROTECTED_REF_PATTERNS = [
-              /^refs\/heads\/main$/,
-              /^refs\/heads\/master$/,
-              /^refs\/heads\/branch-.+$/,
-              /^refs\/tags\/.+$/,
-            ];
-            const isProtectedRef = PROTECTED_REF_PATTERNS.some(pattern => pattern.test(ref));
-
+            const PROTECTED_REF_PATTERNS = [/^refs\/heads\/main$/, /^refs\/heads\/master$/, /^refs\/heads\/branch-.+$/, /^refs\/tags\/.+$/];
+            const isProtectedRef = PROTECTED_REF_PATTERNS.some(p => p.test(ref));
             selectedRole = isProtectedRef ? `${baseRole}-protected` : baseRole;
             core.info(`Auto-selected role: ${selectedRole} (ref: ${ref}, protected: ${isProtectedRef})`);
           }
-
           core.setOutput('vault-role', selectedRole)
     - name: Vault Secrets
       id: secrets
@@ -114,63 +86,45 @@ runs:
           const vaultUrl = process.env.VAULT_URL.replace(/\/+$/, '');
           const vaultRole = process.env.VAULT_ROLE;
           const secretPattern = process.env.SECRET_PATTERN;
-
           const secretPaths = [...new Set(
-            secretPattern
-              .split(/[;\n]/)
-              .map(line => line.trim())
-              .filter(line => line.length > 0)
-              .map(line => line.split(/\s+/)[0])
-              .filter(path => path.length > 0)
+            secretPattern.split(/[;\n]/).map(l => l.trim()).filter(l => l.length > 0)
+              .map(l => l.split(/\s+/)[0]).filter(p => p.length > 0)
           )];
-
           if (secretPaths.length === 0) {
             core.setFailed('Vault action failed but could not parse secret paths for diagnosis.');
             return;
           }
-
           let vaultToken;
           try {
-            const idToken = await core.getIDToken(vaultUrl);
+            const idToken = await core.getIDToken();
             const loginResp = await fetch(`${vaultUrl}/v1/auth/jwt-ghwf/login`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ role: vaultRole, jwt: idToken }),
             });
-
             if (!loginResp.ok) {
               const body = await loginResp.text();
-              core.setFailed(
-                `Cannot diagnose individual secrets — Vault login failed (${loginResp.status}). ` +
-                `The role "${vaultRole}" may not exist or is misconfigured.\n${body}`
-              );
+              core.setFailed(`Cannot diagnose individual secrets — Vault login failed (${loginResp.status}). The role "${vaultRole}" may not exist or is misconfigured.\n${body}`);
               return;
             }
-
             const loginData = await loginResp.json();
             vaultToken = loginData.auth.client_token;
           } catch (err) {
             core.setFailed(`Cannot diagnose individual secrets: ${err.message}`);
             return;
           }
-
           core.info('');
           core.info('=== Diagnosing Vault secret access failure ===');
           core.info(`Role: ${vaultRole}`);
           core.info('');
-
           const denied = [];
           for (const secretPath of secretPaths) {
             try {
               const resp = await fetch(`${vaultUrl}/v1/sys/capabilities-self`, {
                 method: 'POST',
-                headers: {
-                  'X-Vault-Token': vaultToken,
-                  'Content-Type': 'application/json',
-                },
+                headers: { 'X-Vault-Token': vaultToken, 'Content-Type': 'application/json' },
                 body: JSON.stringify({ path: secretPath }),
               });
-
               if (resp.ok) {
                 const data = await resp.json();
                 const caps = data.capabilities || [];
@@ -187,17 +141,11 @@ runs:
               core.warning(`  ???     ${secretPath} (${err.message})`);
             }
           }
-
           core.info('');
           if (denied.length > 0) {
             core.info('To fix, update the Vault policy for this repository:');
             core.info('https://github.com/SonarSource/re-terraform-aws-vault/tree/master/orders');
-            core.setFailed(
-              `Vault secrets retrieval failed — ${denied.length} path(s) denied: ${denied.join(', ')}`
-            );
+            core.setFailed(`Vault secrets retrieval failed — ${denied.length} path(s) denied: ${denied.join(', ')}`);
           } else {
-            core.setFailed(
-              'Vault secrets retrieval failed but all paths appear individually accessible. ' +
-              'The error may be transient or caused by a different issue.'
-            );
+            core.setFailed('Vault secrets retrieval failed but all paths appear individually accessible. The error may be transient or caused by a different issue.');
           }


### PR DESCRIPTION
## Summary

Resolves [PREQ-4481](https://sonarsource.atlassian.net/browse/PREQ-4481) — when `hashicorp/vault-action` fails with a 403 Forbidden, the logs show all requested secrets but don't indicate which one caused the failure. This forces users to debug by trial-and-error.

This PR adds a **diagnostic step** that runs only when the Vault secrets step fails. It:

1. Authenticates to Vault using a fresh OIDC token
2. Checks per-path capabilities via `sys/capabilities-self` (no side effects — does not read actual secrets or generate dynamic credentials)
3. Reports which specific secret path(s) are `DENIED` vs `OK`
4. Points the user to the [Vault orders repository](https://github.com/SonarSource/re-terraform-aws-vault/tree/master/orders) to fix permissions

### Example output

```text
=== Diagnosing Vault secret access failure ===
Role: github-SonarSource-my-repo

  OK      development/kv/data/repox (read)
  DENIED  development/kv/data/slack
  DENIED  development/artifactory/token/SonarSource-my-repo-promoter

To fix, update the Vault policy for this repository:
https://github.com/SonarSource/re-terraform-aws-vault/tree/master/orders
```

### Design decisions

- **Zero overhead on success**: The diagnostic step only runs when the Vault secrets step fails (`continue-on-error: true` + `if: steps.secrets.outcome == 'failure'`)
- **`sys/capabilities-self` instead of direct reads**: Avoids generating dynamic secrets (Artifactory tokens, GitHub tokens, etc.) as a side effect. Only checks permissions.
- **Graceful degradation**: If the diagnostic authentication itself fails (e.g., role doesn't exist), the step reports that clearly and still fails the action
- **No new dependencies**: Reuses `actions/github-script` (already used in the replace step) and Node.js built-in `fetch`

### Related

- [PREQ-4482](https://sonarsource.atlassian.net/browse/PREQ-4482) — sibling ticket, concrete 403 case from the same reporter that motivated this improvement
- Past tickets with the same debugging pain: PREQ-3261, PREQ-385, PREQ-1145, PREQ-1208, PREQ-248

## Test plan

### What we tested

- The diagnostic step correctly identifies which secret path(s) cause the 403
- Allowed secrets show `OK` with their capability (e.g. `read`)
- Denied secrets show `DENIED`
- The fix message and link to re-terraform-aws-vault are displayed
- The action still fails with a clear summary (e.g. `Vault secrets retrieval failed — 1 path(s) denied: operations/team/re/kv/data/digicert`)

### How we tested

1. **Test repo**: [sonar-dummy](https://github.com/SonarSource/sonar-dummy) — a repo with known Vault permissions defined in [re-terraform-aws-vault/orders/platform-eng-xp-squad.yaml](https://github.com/SonarSource/re-terraform-aws-vault/blob/master/orders/platform-eng-xp-squad.yaml)
2. **Allowed secret**: `development/kv/data/slack` — sonar-dummy has access
3. **Denied secret**: `operations/team/re/kv/data/digicert` — RE team only, sonar-dummy has no access
4. **Test workflow**: [`.github/workflows/test-vault-403-diagnostics.yml`](https://github.com/SonarSource/sonar-dummy/blob/PREQ-4481/test-vault-403-diagnostics/.github/workflows/test-vault-403-diagnostics.yml) — requests both secrets to trigger a 403, then runs the diagnostic step

### Test workflow run

- [sonar-dummy PR #563](https://github.com/SonarSource/sonar-dummy/pull/563) — draft PR with the test workflow
- [Workflow run 22661709735](https://github.com/SonarSource/sonar-dummy/actions/runs/22661709735) — validates batched `sys/capabilities-self` API and OIDC fix:

  ```
  === Diagnosing Vault secret access failure ===
  Role: github-SonarSource-sonar-dummy

    OK      development/kv/data/slack (read)
    DENIED  operations/team/re/kv/data/digicert

  To fix, update the Vault policy for this repository:
  https://github.com/SonarSource/re-terraform-aws-vault/tree/master/orders

  Vault secrets retrieval failed — 1 path(s) denied: operations/team/re/kv/data/digicert
  ```

### Checklist

- [x] Verify the diagnostic output correctly identifies denied vs allowed paths
- [x] Test with a repo that has a known missing secret (sonar-dummy + digicert)
- [x] Verify the action still fails properly (the diagnostic step calls `core.setFailed()`)
- [x] Verify the existing test workflow passes (happy path — valid secrets still work with `continue-on-error: true`)
- [x] Verify the `outputs.vault` is still available on success

[PREQ-4481]: https://sonarsource.atlassian.net/browse/PREQ-4481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PREQ-4482]: https://sonarsource.atlassian.net/browse/PREQ-4482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ