### PR TITLE
BUILD-10632 Improve Vault diagnostic error messages with actionable guidance

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -91,14 +91,16 @@ runs:
           const vaultUrl = process.env.VAULT_URL.replace(/\/+$/, '');
           const vaultRole = process.env.VAULT_ROLE;
           const secretPattern = process.env.SECRET_PATTERN;
-          const secretPaths = [...new Set(
-            secretPattern.split(/[;\n]/).map(l => l.trim()).filter(l => l.length > 0)
-              .map(l => l.split(/\s+/)[0]).filter(p => p.length > 0)
-          )];
-          if (secretPaths.length === 0) {
-            core.setFailed('Vault action failed but could not parse secret paths for diagnosis.');
-            return;
-          }
+          const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}` +
+            `/actions/runs/${process.env.GITHUB_RUN_ID}`;
+          const SUPPORT_CHANNEL = '#ask-squad-eng-xp';
+          const TERRAFORM_REPO = 'https://github.com/SonarSource/re-terraform-aws-vault';
+          const PORT_SELF_SERVICE = 'https://app.getport.io/self-serve?action=manage_vault_policy';
+          const DEBUG_HINT =
+            `To investigate further, use the Claude Code developer-tooling plugin\n` +
+            `(https://github.com/SonarSource/awesome-ai) and run the\n` +
+            `debug-github-actions skill with this workflow run URL:\n` +
+            `  ${runUrl}`;
           let vaultToken;
           try {
             const idToken = await core.getIDToken();
@@ -108,16 +110,48 @@ runs:
               body: JSON.stringify({ role: vaultRole, jwt: idToken }),
             });
             if (!loginResp.ok) {
+              const status = loginResp.status;
               const body = await loginResp.text();
-              const msg = `Cannot diagnose individual secrets — Vault login failed (${loginResp.status}). ` +
-                `The role "${vaultRole}" may not exist or is misconfigured.\n${body}`;
-              core.setFailed(msg);
+              if (status >= 500 && status <= 599) {
+                core.setFailed(
+                  `Vault authentication failed (HTTP ${status}) due to a Vault/server-side error.\n\n` +
+                  `Try rerunning this workflow once.\n` +
+                  `If it still fails, check https://sonarsource-internal.statuspage.io/.\n` +
+                  `If there is no ongoing incident, ask for help in ${SUPPORT_CHANNEL}.\n\n` +
+                  `Details: ${body}`
+                );
+                return;
+              }
+              core.setFailed(
+                `Vault authentication failed (HTTP ${status}) — ` +
+                `the role "${vaultRole}" does not exist or is not authorized.\n\n` +
+                `This usually means the repository has not been onboarded to Vault, ` +
+                `or the Vault role is misconfigured.\n` +
+                `To fix, add or update this repository's Vault role in:\n` +
+                `  ${TERRAFORM_REPO}\n\n` +
+                `${DEBUG_HINT}\n\n` +
+                `If you still need help, ask in ${SUPPORT_CHANNEL}.\n\n` +
+                `Details: ${body}`
+              );
               return;
             }
             const loginData = await loginResp.json();
             vaultToken = loginData.auth.client_token;
           } catch (err) {
-            core.setFailed(`Cannot diagnose individual secrets: ${err.message}`);
+            core.setFailed(
+              `Vault authentication failed — could not obtain a Vault token.\n\n` +
+              `${DEBUG_HINT}\n\n` +
+              `If you still need help, ask in ${SUPPORT_CHANNEL}.\n\n` +
+              `Error: ${err.message}`
+            );
+            return;
+          }
+          const secretPaths = [...new Set(
+            secretPattern.split(/[;\n]/).map(l => l.trim()).filter(l => l.length > 0)
+              .map(l => l.split(/\s+/)[0]).filter(p => p.length > 0)
+          )];
+          if (secretPaths.length === 0) {
+            core.setFailed('Vault action failed but could not parse secret paths for diagnosis.');
             return;
           }
           core.info('');
@@ -163,12 +197,31 @@ runs:
           }
           core.info('');
           if (denied.length > 0) {
-            core.info('To fix, update the Vault policy for this repository:');
-            core.info('https://github.com/SonarSource/re-terraform-aws-vault/tree/master/orders');
-            core.setFailed(`Vault secrets retrieval failed — ${denied.length} path(s) denied: ${denied.join(', ')}`);
+            // All KV secret paths contain '/kv/' in their mount path
+            const deniedKv = denied.filter(p => p.includes('/kv/'));
+            const deniedDynamic = denied.filter(p => !p.includes('/kv/'));
+            let msg = `Vault secret access denied for ${denied.length} path(s).\n\n`;
+            if (deniedKv.length > 0) {
+              msg +=
+                `The following path(s) need a policy update — you can fix this yourself\n` +
+                `using the self-service portal:\n` +
+                `  ${deniedKv.join('\n  ')}\n` +
+                `Grant access here: ${PORT_SELF_SERVICE}\n\n`;
+            }
+            if (deniedDynamic.length > 0) {
+              msg +=
+                `The following path(s) require a Vault policy change — request it\n` +
+                `in the infrastructure repo:\n` +
+                `  ${deniedDynamic.join('\n  ')}\n` +
+                `Update the policy here: ${TERRAFORM_REPO}\n\n`;
+            }
+            msg += `${DEBUG_HINT}\n\n`;
+            msg += `If you still need help, ask in ${SUPPORT_CHANNEL}.`;
+            core.setFailed(msg);
           } else {
             core.setFailed(
-              'Vault secrets retrieval failed but all paths appear individually accessible. ' +
-              'The error may be transient or caused by a different issue.'
+              `Vault secrets retrieval failed but the root cause could not be determined automatically.\n\n` +
+              `${DEBUG_HINT}\n\n` +
+              `If you still need help, ask in ${SUPPORT_CHANNEL}.`
             );
           }


### PR DESCRIPTION
BUILD-10632

## Why

Error messages in the Vault diagnostic step are terse and developer-facing. Users hitting failures get no remediation steps, no links, and jargon like "KV" or "dynamic secrets" — leading to avoidable support requests in `#ask-squad-eng-xp`.

## What changed

All changes are in `action.yaml`, in the "Diagnose secret access failures" step. No changes to the diagnostic logic itself (capability checks, login flow, path parsing).

### Constants extracted

Repeated strings (`SUPPORT_CHANNEL`, `TERRAFORM_REPO`, `PORT_SELF_SERVICE`, `DEBUG_HINT`) are now defined once at the top of the script block for easy maintenance.

### Error branches — before vs after

| Scenario | Before | After |
|---|---|---|
| **5xx server error** | *(not handled — fell through to the generic 4xx message)* | Dedicated branch: suggests rerunning the workflow, links to the status page, then `#ask-squad-eng-xp` |
| **4xx auth error** (role missing/misconfigured) | `Cannot diagnose individual secrets — Vault login failed (status). The role "..." may not exist or is misconfigured.` | Explains the likely cause (repo not onboarded / role misconfigured), links to the terraform repo to fix, includes the debug hint |
| **Auth exception** (network/token error) | `Cannot diagnose individual secrets: <error>` | Includes the debug hint + support channel |
| **Denied paths** | `Vault secrets retrieval failed — N path(s) denied: path1, path2` + a generic `core.info` link to the terraform repo | Splits paths into KV vs non-KV using the `/kv/` heuristic. KV paths → Port self-service portal link (user can fix themselves). Non-KV paths → terraform repo link. Lists the actual denied paths under each category. |
| **Unknown failure** (no denied paths found) | `Vault secrets retrieval failed but all paths appear individually accessible. The error may be transient or caused by a different issue.` | Includes the debug hint + support channel |

### Consistent escalation path

Every error branch now follows: specific remediation action → Claude Code `debug-github-actions` skill (with workflow run URL) → `#ask-squad-eng-xp` as last resort.

### Code reordering

`secretPaths` parsing moved after the auth block — it's not needed if auth fails, and this avoids a confusing "could not parse secret paths" error when the real problem is auth.

## Behavioral notes

- Error messages are intentionally longer — the goal is to reduce back-and-forth by giving users everything they need in one message.
- The `/kv/` path heuristic matches all current Vault mount conventions at SonarSource.