### PR TITLE
BUILD-11263: Update ask-squad-eng-xp Slack reference to ask-platform-eng-xp

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -93,7 +93,7 @@ runs:
           const secretPattern = process.env.SECRET_PATTERN;
           const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}` +
             `/actions/runs/${process.env.GITHUB_RUN_ID}`;
-          const SUPPORT_CHANNEL = '#ask-squad-eng-xp';
+          const SUPPORT_CHANNEL = '#ask-platform-eng-xp';
           const TERRAFORM_REPO = 'https://github.com/SonarSource/re-terraform-aws-vault';
           const PORT_SELF_SERVICE = 'https://app.getport.io/self-serve?action=manage_vault_policy';
           const DEBUG_HINT =


### PR DESCRIPTION
BUILD-11263

The Platform team is renaming the `#ask-squad-eng-xp` Slack channel to `#ask-platform-eng-xp`. Updates the `SUPPORT_CHANNEL` constant used in user-facing error messages so the printed channel name matches reality after the rename. Channel ID (`C04CVEU7734`) is unchanged.

Slack thread: https://sonarsource.slack.com/archives/C01Q81WPFD3/p1777892036470959