### PR TITLE
BUILD-10781 Bump JS deps to Node 24 runtimes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: exec vault-action
         id: actual
         uses: ./

--- a/action.yaml
+++ b/action.yaml
@@ -37,7 +37,7 @@ runs:
       env:
         SECRET_PATTERN: ${{ inputs.secrets }}
         INPUT_ROLE: ${{ inputs.role }}
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
       with:
         script: |
           core.setOutput('pattern',
@@ -69,7 +69,7 @@ runs:
     - name: Vault Secrets
       id: secrets
       continue-on-error: true
-      uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b  # v3.4.0
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc  # v4.0.0
       with:
         url: ${{ inputs.url }}
         exportEnv: false
@@ -81,7 +81,7 @@ runs:
     - name: Diagnose secret access failures
       id: diagnose
       if: steps.secrets.outcome == 'failure'
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
       env:
         VAULT_URL: ${{ inputs.url }}
         VAULT_ROLE: ${{ steps.replace.outputs.vault-role }}


### PR DESCRIPTION
## Why

GitHub deprecates Node 20 on Actions runners starting **2026-06-02**. This wrapper's two JS dependencies still run on Node 20:

- `actions/github-script@v7.0.1`
- `hashicorp/vault-action@v3.4.0`

Both have shipped Node 24-compatible majors.

Linked ticket: [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781).

## What changed

- `actions/github-script` v7.0.1 → **v9.0.0** (Node 24).
- `hashicorp/vault-action` v3.4.0 → **v4.0.0** (Node 24 + fix for leading slash in secret paths).
- `actions/checkout` v5.0.0 → **v6.0.2** in the test workflow.

## Breaking-change risk assessment

`github-script@v9` introduces two breakages:
- `require('@actions/github')` no longer works at runtime — **not used** in the two script bodies here.
- `getOctokit` is now an injected parameter; scripts redeclaring it with `const`/`let` get a `SyntaxError` — **not used** here either.

So this bump is drop-in for our usage.

## Supersedes

PR #65 (Renovate `major-github-actions`) — same diff. The user will close that PR after this lands.

## Verification

- `pre-commit` clean (yamllint, actionlint, validate workflows).
- CI on this PR exercises `test.yaml`, which runs the wrapper end-to-end against Vault.

## Downstream

After release, the leaf wrappers `jfrog-setup-wrapper`, `gh-action_slack-notify`, and `unified-dogfooding-actions/run-iris` need their pinned `vault-action-wrapper` SHA bumped.


[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ