### PR TITLE
BUILD-11126 capture network diagnostics on Vault failure

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   vault-action:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -35,3 +35,48 @@ jobs:
         shell: bash
         run: |
           [[ "${{ fromJSON(steps.actual.outputs.vault).org_name }}" = "SonarSource" ]]
+
+  vault-action-failure-diagnostics:
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: exec vault-action against unreachable host
+        id: failed
+        continue-on-error: true
+        uses: ./
+        with:
+          url: https://vault.invalid.example.test
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-ro token | github_ro;
+      - name: assert action failed and diagnostics were captured
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.failed.outcome }}
+          DIAGNOSTICS: ${{ steps.failed.outputs.diagnostics }}
+        run: |
+          set -euo pipefail
+          echo "outcome=$OUTCOME"
+          echo "--- diagnostics ---"
+          printf '%s\n' "$DIAGNOSTICS"
+          echo "---"
+          if [[ "$OUTCOME" != "failure" ]]; then
+            echo "expected failure, got $OUTCOME"
+            exit 1
+          fi
+          printf '%s\n' "$DIAGNOSTICS" > /tmp/diagnostics
+          required=(
+            '^runner_os='
+            '^egress_ip='
+            '^tcp_probe vault.invalid.example.test:443='
+            '^first_attempt_outcome=failure'
+            '^retry_outcome=failure'
+          )
+          for pattern in "${required[@]}"; do
+            if ! grep -q "$pattern" /tmp/diagnostics; then
+              echo "missing expected pattern: $pattern"
+              exit 1
+            fi
+          done

--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,9 @@ outputs:
       ${{ steps.secrets-retry.outcome == 'success'
       && toJSON(steps.secrets-retry.outputs)
       || toJSON(steps.secrets.outputs) }}
+  diagnostics:
+    description: Network diagnostics captured when the first Vault attempt fails. Empty on success.
+    value: ${{ steps.netdiag.outputs.text }}
 runs:
   using: composite
   steps:
@@ -100,6 +103,68 @@ runs:
         role: ${{ steps.replace.outputs.vault-role }}
         secrets: ${{ steps.replace.outputs.pattern }}
         jwtTtl: ${{ inputs.jwtTtl }}
+    - name: Capture network diagnostics
+      id: netdiag
+      if: steps.secrets.outcome == 'failure'
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+      env:
+        VAULT_URL: ${{ inputs.url }}
+        FIRST_ATTEMPT_OUTCOME: ${{ steps.secrets.outcome }}
+        RETRY_OUTCOME: ${{ steps.secrets-retry.outcome }}
+      with:
+        script: |
+          const text = await gatherNetworkDiagnostics(process.env.VAULT_URL);
+          core.info(`--- network diagnostics ---\n${text}\n---`);
+          core.setOutput('text', text);
+
+          async function gatherNetworkDiagnostics(targetUrl) {
+            try {
+              const net = require('node:net');
+              let hostname, tcpPort;
+              try {
+                const u = new URL(targetUrl);
+                hostname = u.hostname;
+                tcpPort = Number(u.port) || (u.protocol === 'http:' ? 80 : 443);
+              } catch (e) {
+                return `vault_url=${targetUrl}\nurl_parse=ERROR ${e.message}`;
+              }
+              const lines = [
+                `runner_os=${process.env.RUNNER_OS || ''} ` +
+                `runner_arch=${process.env.RUNNER_ARCH || ''} ` +
+                `runner_name=${process.env.RUNNER_NAME || ''}`,
+                `vault_url=${targetUrl}`,
+                `time=${new Date().toISOString()}`,
+                `first_attempt_outcome=${process.env.FIRST_ATTEMPT_OUTCOME || ''}`,
+                `retry_outcome=${process.env.RETRY_OUTCOME || ''}`,
+              ];
+              const ac = new AbortController();
+              const t = setTimeout(() => ac.abort(), 5000);
+              try {
+                const r = await fetch('https://checkip.amazonaws.com', { signal: ac.signal });
+                lines.push(`egress_ip=${(await r.text()).trim()}`);
+              } catch (e) {
+                lines.push(`egress_ip=ERROR ${e.message}`);
+              } finally {
+                clearTimeout(t);
+              }
+              const probe = (host, p) => new Promise(resolve => {
+                const started = Date.now();
+                const s = net.createConnection({ host, port: p });
+                const finish = (result) => {
+                  try { s.destroy(); } catch {}
+                  resolve(`${result} (${Date.now() - started}ms)`);
+                };
+                s.setTimeout(5000);
+                s.once('connect', () => finish('ok'));
+                s.once('timeout', () => finish('timeout'));
+                s.once('error', (err) => finish(`error ${err.code || err.message}`));
+              });
+              lines.push(`tcp_probe ${hostname}:${tcpPort}=${await probe(hostname, tcpPort)}`);
+              return lines.join('\n');
+            } catch (e) {
+              return `diagnostics=ERROR ${e.message}`;
+            }
+          }
     - name: Diagnose secret access failures
       id: diagnose
       if: steps.secrets.outcome == 'failure' && steps.secrets-retry.outcome == 'failure'
@@ -108,6 +173,7 @@ runs:
         VAULT_URL: ${{ inputs.url }}
         VAULT_ROLE: ${{ steps.replace.outputs.vault-role }}
         SECRET_PATTERN: ${{ steps.replace.outputs.pattern }}
+        NETWORK_DIAGNOSTICS: ${{ steps.netdiag.outputs.text }}
       with:
         script: |
           const vaultUrl = process.env.VAULT_URL.replace(/\/+$/, '');
@@ -160,11 +226,14 @@ runs:
             const loginData = await loginResp.json();
             vaultToken = loginData.auth.client_token;
           } catch (err) {
+            const diagnostics = process.env.NETWORK_DIAGNOSTICS || '(not gathered)';
             core.setFailed(
               `Vault authentication failed — could not obtain a Vault token.\n` +
               `An automatic retry was already attempted and also failed.\n\n` +
+              `If the error below is \`fetch failed\`, the request likely never reached Vault ` +
+              `(network/firewall drop). Include the block below when asking for help in ${SUPPORT_CHANNEL}:\n\n` +
+              `--- network diagnostics ---\n${diagnostics}\n---\n\n` +
               `${DEBUG_HINT}\n\n` +
-              `If you still need help, ask in ${SUPPORT_CHANNEL}.\n\n` +
               `Error: ${err.message}`
             );
             return;


### PR DESCRIPTION
## Summary

Adds a new `Capture network diagnostics` step that runs whenever the first Vault attempt fails — **regardless of whether the PREQ-6101 retry then succeeds**. Output is logged to the run, and also wired into the existing `Diagnose secret access failures` step so the final user-facing error message embeds the same block when both attempts fail.

## Why

Investigation on [BUILD-11126](https://sonarsource.atlassian.net/browse/BUILD-11126) traced the canonical `Error: fetch failed` to a TCP SYN drop between GitHub-hosted runners and the Vault ALB:

- Confirmed failure on `sonarcloud-authentication` run [26938524936](https://github.com/SonarSource/sonarcloud-authentication/actions/runs/26938524936/job/79473986527?pr=1354) (2026-06-04 07:52:09→07:54:36 UTC)
- Zero Vault audit entries for that `run_id`; ~185 other JWT logins succeeded in the same 3-min window
- ~2:27 latency before `fetch failed` matches Linux default `tcp_syn_retries=6` (~127 s) — silent SYN drop
- Cause: upstream firewall allowlist isn't tracking the full GitHub Actions egress range set (`gh api meta` lists 5,218 IPv4 + 1,357 IPv6 ranges, churning)

The retry layer (PREQ-6101) is preserved — it doesn't help against a sustained drop but it doesn't hurt, and it does mask transient single-packet glitches.

What was missing was a feedback loop: when a runner hits a non-allowlisted egress IP, we want the IP captured, even if the retry happens to land on a different IP and succeed. This PR gives us that.

## Behaviour

| First attempt | Retry | What we get |
|---|---|---|
| ✅ | (skipped) | Nothing extra |
| ❌ | ✅ | Diagnostics in run log (`Capture network diagnostics` step), job succeeds |
| ❌ | ❌ | Diagnostics in run log **and** embedded in the diagnose step's setFailed message |

Sample output (block users paste back to us):

```
--- network diagnostics ---
runner_os=Linux runner_arch=X64 runner_name=GitHub Actions 42
vault_url=https://vault.sonar.build
time=2026-06-04T07:54:36.000Z
first_attempt_outcome=failure
retry_outcome=failure
egress_ip=20.51.84.123
tcp_probe vault.sonar.build:443=timeout (5004ms)
---
```

`egress_ip` → check against firewall allowlist directly.
`tcp_probe` → distinguishes silent SYN drop (~5 s timeout) from RST (immediate error) from "reached ALB, original fetch failed on something else" (ok in ms).

## The real fix is upstream

This PR closes the feedback loop. The lasting fix is the firewall in front of the Vault ALB auto-syncing GitHub Actions ranges from `https://api.github.com/meta`.

## Test plan

- [ ] CI green (staging Vault integration test)
- [ ] Smoke: force a transport error (e.g. point `url` at an unreachable host) and confirm the diagnostics block appears in both the new step log and the diagnose step's setFailed message
- [ ] After merge + `v3` tag, the next real BUILD-11126 incident produces a diagnostic block we can act on immediately

[BUILD-11126]: https://sonarsource.atlassian.net/browse/BUILD-11126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ